### PR TITLE
Add Name property to GeckoBarChartSeries

### DIFF
--- a/Source/Geckonet.Core/Models/GeckoModels.cs
+++ b/Source/Geckonet.Core/Models/GeckoModels.cs
@@ -859,6 +859,15 @@ namespace Geckonet.Core.Models
 #pragma warning disable 1591
         public bool ShouldSerializeData() { return (Data != null) && (Data.Count > 0); }
 #pragma warning restore 1591
+
+        /// <summary>
+        /// Name
+        /// </summary>
+        [DataMember(Name = "name", IsRequired = false), XmlElement("name"), JsonProperty("name")]
+        public string Name { get; set; }
+#pragma warning disable 1591
+        public bool ShouldSerializeName() { return !string.IsNullOrWhiteSpace(Name); }
+#pragma warning restore 1591
     }
 
     /// <summary>


### PR DESCRIPTION
@kfrancis Hey there! One our customers wrote on our developer forum [1] about wanting to provide the series name for the bar chart, so I thought I'd add it. Fixes #6 

[1] https://community.geckoboard.com/t/multiseries-example-legend/427/3