### PR TITLE
Added possibility to clear a dataset according to the GeckoBoard API …

### DIFF
--- a/Source/Geckonet.Core/GeckoConnect.cs
+++ b/Source/Geckonet.Core/GeckoConnect.cs
@@ -203,5 +203,37 @@ namespace Geckonet.Core
 
             return response.Data;
         }
+
+        /// <summary>
+        /// Clears the dataset
+        /// </summary>
+        /// <param name="name">The name of the dataset</param>
+        /// <param name="apiKey">The api key</param>
+        /// <returns>True if successful, throws GeckoException otherwise.</returns>
+        public bool ClearDataset(string name, string apiKey)
+        {
+            var client = new RestClient("https://api.geckoboard.com")
+            {
+                Authenticator = new HttpBasicAuthenticator(apiKey, string.Empty),
+                UserAgent = UserAgent
+            };
+
+            var request = new RestRequest($"datasets/{name}/data", Method.PUT)
+            {
+                RequestFormat = DataFormat.Json
+            };
+            request.AddHeader("Content-Type", "application/json");
+            request.JsonSerializer = new RestSharpJsonNetSerializer();
+            request.AddParameter("application/json", request.JsonSerializer.Serialize(new { Data = new List<int>() }), ParameterType.RequestBody);
+
+            var response = client.Execute(request);
+
+            if (response.StatusCode != System.Net.HttpStatusCode.OK)
+            {
+                throw new GeckoException(response.StatusDescription, response.Content);
+            }
+
+            return true;
+        }
     }
 }

--- a/Source/Geckonet.Tests/DatasetTests.cs
+++ b/Source/Geckonet.Tests/DatasetTests.cs
@@ -117,5 +117,35 @@ namespace Geckonet.Tests
 
             client.DeleteDataset(datasetName, _apiKey);
         }
+
+        [TestMethod]
+        public void Live_Clear_Data_In_Dataset()
+        {
+            // Arrange
+            var client = new GeckoConnect();
+
+            var obj = new GeckoDataset()
+            {
+                Fields = new Dictionary<string, IDatasetField>()
+                {
+                    {"amount", new DatasetField(DatasetFieldType.Number, "Amount")},
+                    {"timestamp", new DatasetField(DatasetFieldType.DateTime, "Date")}
+                },
+                UniqueBy = new List<string>() { "timestamp" }
+            };
+            var datasetName = $"test_{Guid.NewGuid().ToString()}";
+
+            // Act
+            Assert.AreNotEqual("<api key here>", _apiKey);
+
+            var result = client.CreateDataset(obj, datasetName, _apiKey);
+            var result2 = client.ClearDataset(datasetName, _apiKey);
+
+
+            // Assert
+            Assert.IsNotNull(result);
+
+            client.DeleteDataset(datasetName, _apiKey);
+        }
     }
 }


### PR DESCRIPTION
I added functionality to the geckonet nuget package so we can clear a dataset. It's i.e. usable if we need to replace a dataset with more than 500 rows.

It's implemented from this article: https://developer.geckoboard.com/hc/en-us/articles/360019664332-Clear-all-data-within-a-dataset